### PR TITLE
[0.x] Support username and database index options for the Redis adapter

### DIFF
--- a/docs/ENV.md
+++ b/docs/ENV.md
@@ -179,7 +179,9 @@ Configuration needed to connect to a Redis server.
 | - | - | - | - |
 | `DB_REDIS_HOST` | `127.0.0.1` | - | The Redis host used for `redis` driver. |
 | `DB_REDIS_PORT` | `6379` | - | The Redis port used for `redis` driver. |
-| `DB_REDIS_PASSWORD` | `null` | - | The Redis password used for `redis` driver. |
+| `DB_REDIS_DB` | `0` | - | The Redis database used for `redis` driver. |
+| `DB_REDIS_USERNAME` | `null` | - | The Redis username used for authentication for `redis` driver. |
+| `DB_REDIS_PASSWORD` | `null` | - | The Redis password used for authentication for `redis` driver. |
 | `DB_REDIS_PREFIX` | `pws` | - | The key prefix for Redis. Only for `redis` driver. |
 
 ## Database Pooling

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -46,6 +46,8 @@ export class Cli {
         DB_POSTGRES_DATABASE: 'database.postgres.database',
         DB_REDIS_HOST: 'database.redis.host',
         DB_REDIS_PORT: 'database.redis.port',
+        DB_REDIS_DB: 'database.redis.db',
+        DB_REDIS_USERNAME: 'database.redis.username',
         DB_REDIS_PASSWORD: 'database.redis.password',
         DB_REDIS_KEY_PREFIX: 'database.redis.keyPrefix',
         EVENT_MAX_CHANNELS_AT_ONCE: 'eventLimits.maxChannelsAtOnce',

--- a/src/options.ts
+++ b/src/options.ts
@@ -3,6 +3,8 @@ import { AppInterface } from './app';
 interface Redis {
     host: string;
     port: number;
+    db: number;
+    username: string|null;
     password: string|null;
     keyPrefix: string;
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -88,6 +88,8 @@ export class Server {
             redis: {
                 host: '127.0.0.1',
                 port: 6379,
+                db: 0,
+                username: null,
                 password: null,
                 keyPrefix: '',
             },


### PR DESCRIPTION
This PR adds support for the [`ioredis` options `username` and `db`](https://github.com/luin/ioredis/blob/master/API.md#new-redisport-host-options), which are quite common ones to be used in production. There isn't really much to it, the new environment variables are passed down to the adapter similar to `DB_REDIS_PORT` for example.