### PR TITLE
[0.x] Cleanup channels on removeSocket()

### DIFF
--- a/src/namespace.ts
+++ b/src/namespace.ts
@@ -40,9 +40,9 @@ export class Namespace {
      * Remove a socket from the namespace.
      */
     async removeSocket(wsId: string): Promise<boolean> {
-        this.channels.forEach(async (sockets, channel) => {
-            await this.removeFromChannel(wsId, channel); 
-        });
+        for (let channel of this.channels.keys()){
+            await this.removeFromChannel(wsId, channel);
+        }
 
         return this.sockets.delete(wsId);
     }
@@ -67,7 +67,7 @@ export class Namespace {
      * Remove a socket ID from the channel identifier.
      * Return the total number of connections remaining to the channel.
      */
-    removeFromChannel(wsId: string, channel: string): Promise<number> {
+    async removeFromChannel(wsId: string, channel: string): Promise<number> {
         return new Promise(resolve => {
             if (this.channels.has(channel)) {
                 this.channels.get(channel).delete(wsId);

--- a/src/namespace.ts
+++ b/src/namespace.ts
@@ -40,7 +40,7 @@ export class Namespace {
      * Remove a socket from the namespace.
      */
     async removeSocket(wsId: string): Promise<boolean> {
-        this.channels.forEach((sockets, channel) => {
+        this.channels.forEach(async (sockets, channel) => {
             await this.removeFromChannel(wsId, channel); 
         });
 

--- a/src/namespace.ts
+++ b/src/namespace.ts
@@ -39,8 +39,12 @@ export class Namespace {
     /**
      * Remove a socket from the namespace.
      */
-    removeSocket(wsId: string): Promise<boolean> {
-        return Promise.resolve(this.sockets.delete(wsId));
+    async removeSocket(wsId: string): Promise<boolean> {
+        for (let channel of this.channels.keys()){
+            await this.removeFromChannel(wsId, channel)
+        }
+
+        return this.sockets.delete(wsId);
     }
 
     /**

--- a/src/namespace.ts
+++ b/src/namespace.ts
@@ -40,9 +40,9 @@ export class Namespace {
      * Remove a socket from the namespace.
      */
     async removeSocket(wsId: string): Promise<boolean> {
-        for (let channel of this.channels.keys()){
-            await this.removeFromChannel(wsId, channel)
-        }
+        this.channels.forEach((sockets, channel) => {
+            await this.removeFromChannel(wsId, channel); 
+        });
 
         return this.sockets.delete(wsId);
     }

--- a/tests/http-api.redis-adapter.test.ts
+++ b/tests/http-api.redis-adapter.test.ts
@@ -47,8 +47,7 @@ describe('http api test for redis adapter', () => {
 
                                         client2.connection.bind('disconnected', () => {
                                             backend.get({ path: '/channels' }).then(res => res.json()).then(body => {
-                                                // TODO: Expect
-                                                // expect(body.channels[channelName]).toBeUndefined();
+                                                expect(body.channels[channelName]).toBeUndefined();
                                                 done();
                                             });
                                         });

--- a/tests/http-api.redis-adapter.test.ts
+++ b/tests/http-api.redis-adapter.test.ts
@@ -47,7 +47,8 @@ describe('http api test for redis adapter', () => {
 
                                         client2.connection.bind('disconnected', () => {
                                             backend.get({ path: '/channels' }).then(res => res.json()).then(body => {
-                                                expect(body.channels[channelName]).toBeUndefined();
+                                                // TODO: Expect
+                                                // expect(body.channels[channelName]).toBeUndefined();
                                                 done();
                                             });
                                         });

--- a/tests/presence.test.ts
+++ b/tests/presence.test.ts
@@ -187,8 +187,7 @@ describe('presence channel test', () => {
                         let socket = namespace.sockets.get(namespace.sockets.keys().next().value);
 
                         expect(namespace.channels.size).toBe(0);
-                        // TODO: This assertion is crazy
-                        // expect(namespace.sockets.size).toBe(1);
+                        expect(namespace.sockets.size).toBe(1);
                         expect(socket.subscribedChannels.size).toBe(0);
                         expect(socket.presence.size).toBe(0);
 
@@ -221,8 +220,7 @@ describe('presence channel test', () => {
                 Utils.wait(3000).then(() => {
                     let namespace = server.adapter.getNamespace('app-id');
 
-                    // TODO: This assertion is crazy
-                    // expect(namespace.sockets.size).toBe(0);
+                    expect(namespace.sockets.size).toBe(0);
                     expect(namespace.channels.size).toBe(0);
 
                     done();

--- a/tests/private.test.ts
+++ b/tests/private.test.ts
@@ -78,8 +78,7 @@ describe('private channel test', () => {
                 Utils.wait(3000).then(() => {
                     let namespace = server.adapter.getNamespace('app-id');
 
-                    // TODO: This assertion is crazy
-                    // expect(namespace.sockets.size).toBe(0);
+                    expect(namespace.sockets.size).toBe(0);
                     expect(namespace.channels.size).toBe(0);
 
                     done();
@@ -99,8 +98,7 @@ describe('private channel test', () => {
                         let socket = namespace.sockets.get(namespace.sockets.keys().next().value);
 
                         expect(namespace.channels.size).toBe(0);
-                        // TODO: This assertion is crazy
-                        // expect(namespace.sockets.size).toBe(1);
+                        expect(namespace.sockets.size).toBe(1);
                         expect(socket.subscribedChannels.size).toBe(0);
                         expect(socket.presence.size).toBe(0);
 
@@ -125,8 +123,7 @@ describe('private channel test', () => {
                 Utils.wait(3000).then(() => {
                     let namespace = server.adapter.getNamespace('app-id');
 
-                    // TODO: This assertion is crazy
-                    // expect(namespace.sockets.size).toBe(0);
+                    expect(namespace.sockets.size).toBe(0);
                     expect(namespace.channels.size).toBe(0);
 
                     done();


### PR DESCRIPTION
Sometimes sockets still present in channels sets after disconnecting. 
I still could not find out why this happens.