### PR TITLE
[0.x] Add parameter to prefix the route URLs

### DIFF
--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -66,6 +66,7 @@ export class Cli {
         NODE_ID: 'instance.node_id',
         POD_ID: 'instance.pod_id',
         PORT: 'port',
+        PATH_PREFIX: 'pathPrefix',
         PRESENCE_MAX_MEMBER_SIZE: 'presence.maxMemberSizeInKb',
         PRESENCE_MAX_MEMBERS: 'presence.maxMembersPerChannel',
         QUEUE_DRIVER: 'queue.driver',

--- a/src/options.ts
+++ b/src/options.ts
@@ -92,6 +92,7 @@ export interface Options {
         };
     },
     port: number;
+    pathPrefix: string;
     presence: {
         maxMembersPerChannel: string|number;
         maxMemberSizeInKb: string|number;


### PR DESCRIPTION
This PR adds the capability to add a `pathPrefix` to all the urls.

The main usage will be to people that use proxies like `traefik` or `k8s ingress controller`, this way on a domain `https://example.com` can the be web server and `https://example.com/ws` will be the pWS server both working on the same port.

Hope this is helpful.
Thanks,
Francisco