### PR TITLE
Handle invalid json in messages

### DIFF
--- a/src/ws-handler.ts
+++ b/src/ws-handler.ts
@@ -139,7 +139,11 @@ export class WsHandler {
      */
     onMessage(ws: WebSocket, message: any, isBinary: boolean): any {
         if (message instanceof ArrayBuffer) {
-            message = JSON.parse(ab2str(message));
+            try {
+                message = JSON.parse(ab2str(message));
+            } catch (err) {
+                return;
+            }
         }
 
         if (message) {


### PR DESCRIPTION
Was setting this up and accidentally sent invalid JSON to the server when I was testing with websocat.  It appears the JSON.parse had no error handling so it crashed the process.  This try / catch seems to tidy things up!

Great work on this package by the way!