### PR TITLE
Fix webhook payload format

### DIFF
--- a/.github/workflows/docker-commit.yml
+++ b/.github/workflows/docker-commit.yml
@@ -17,6 +17,8 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
+      fail-fast: false
+
       matrix:
         node:
           - 14-alpine

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,6 +1,5 @@
 import { HttpResponse } from 'uWebSockets.js';
 
-const { createHmac } = require('crypto');
 const Pusher = require('pusher');
 const pusherUtil = require('pusher/lib/util');
 
@@ -97,15 +96,6 @@ export class App implements AppInterface {
         if (!(this.webhooks instanceof Array)) {
             this.webhooks = [];
         }
-    }
-
-    /**
-     * Create the HMAC for the given data.
-     */
-    createWebhookHmac(data: string): string {
-        return createHmac('sha256', this.secret)
-            .update(data)
-            .digest('hex');
     }
 
     /**

--- a/src/webhook-sender.ts
+++ b/src/webhook-sender.ts
@@ -118,8 +118,8 @@ export class WebhookSender {
      */
     protected send(app: App, data: ClientEventData, queueName: string): void {
         let dataToSend = {
-            ...data,
-            ...{ time_ms: (new Date).getTime() },
+            time_ms: (new Date).getTime(),
+            events: [data],
         };
 
         let headers = {

--- a/tests/webhooks.test.ts
+++ b/tests/webhooks.test.ts
@@ -1,6 +1,7 @@
 import { App } from '../src/app';
 import { Server } from '../src/server';
 import { Utils } from './utils';
+import { createWebhookHmac } from "../src/webhook-sender";
 
 jest.retryTimes(2);
 
@@ -30,7 +31,7 @@ describe('webhooks test', () => {
         }, (server: Server) => {
             Utils.newWebhookServer((req, res) => {
                 let app = new App(server.options.appManager.array.apps[0]);
-                let rightSignature = app.createWebhookHmac(JSON.stringify(req.body));
+                let rightSignature = createWebhookHmac(JSON.stringify(req.body), app.secret);
 
                 expect(req.headers['x-pusher-key']).toBe('app-key');
                 expect(req.headers['x-pusher-signature']).toBe(rightSignature);
@@ -87,7 +88,7 @@ describe('webhooks test', () => {
         }, (server: Server) => {
             Utils.newWebhookServer((req, res) => {
                 let app = new App(server.options.appManager.array.apps[0]);
-                let rightSignature = app.createWebhookHmac(JSON.stringify(req.body));
+                let rightSignature = createWebhookHmac(JSON.stringify(req.body), app.secret);
 
                 expect(req.headers['x-pusher-key']).toBe('app-key');
                 expect(req.headers['x-pusher-signature']).toBe(rightSignature);
@@ -136,7 +137,7 @@ describe('webhooks test', () => {
         }, (server: Server) => {
             Utils.newWebhookServer((req, res) => {
                 let app = new App(server.options.appManager.array.apps[0]);
-                let rightSignature = app.createWebhookHmac(JSON.stringify(req.body));
+                let rightSignature = createWebhookHmac(JSON.stringify(req.body), app.secret);
 
                 expect(req.headers['x-pusher-key']).toBe('app-key');
                 expect(req.headers['x-pusher-signature']).toBe(rightSignature);

--- a/tests/webhooks.test.ts
+++ b/tests/webhooks.test.ts
@@ -34,12 +34,17 @@ describe('webhooks test', () => {
 
                 expect(req.headers['x-pusher-key']).toBe('app-key');
                 expect(req.headers['x-pusher-signature']).toBe(rightSignature);
-                expect(req.body.name).toBe('client_event');
-                expect(req.body.channel).toBe(channelName);
-                expect(req.body.event).toBe('client-greeting');
-                expect(req.body.data.message).toBe('hello');
-                expect(req.body.socket_id).toBeDefined();
                 expect(req.body.time_ms).toBeDefined();
+                expect(req.body.events).toBeDefined();
+                expect(req.body.events.length).toBe(1);
+
+                const webhookEvent = req.body.events[0];
+
+                expect(webhookEvent.name).toBe('client_event');
+                expect(webhookEvent.channel).toBe(channelName);
+                expect(webhookEvent.event).toBe('client-greeting');
+                expect(webhookEvent.data.message).toBe('hello');
+                expect(webhookEvent.socket_id).toBeDefined();
 
                 res.json({ ok: true });
                 done();
@@ -86,17 +91,20 @@ describe('webhooks test', () => {
 
                 expect(req.headers['x-pusher-key']).toBe('app-key');
                 expect(req.headers['x-pusher-signature']).toBe(rightSignature);
+                expect(req.body.time_ms).toBeDefined();
+                expect(req.body.events).toBeDefined();
+                expect(req.body.events.length).toBe(1);
 
-                if (req.body.name === 'channel_occupied') {
-                    expect(req.body.channel).toBe(channelName);
-                    expect(req.body.time_ms).toBeDefined();
+                const webhookEvent = req.body.events[0];
+
+                if (webhookEvent.name === 'channel_occupied') {
+                    expect(webhookEvent.channel).toBe(channelName);
                 }
 
                 res.json({ ok: true });
 
-                if (req.body.name === 'channel_vacated') {
-                    expect(req.body.channel).toBe(channelName);
-                    expect(req.body.time_ms).toBeDefined();
+                if (webhookEvent.name === 'channel_vacated') {
+                    expect(webhookEvent.channel).toBe(channelName);
                     done();
                 }
             }, (activeHttpServer) => {
@@ -132,19 +140,23 @@ describe('webhooks test', () => {
 
                 expect(req.headers['x-pusher-key']).toBe('app-key');
                 expect(req.headers['x-pusher-signature']).toBe(rightSignature);
+                expect(req.body.time_ms).toBeDefined();
+                expect(req.body.events).toBeDefined();
+                expect(req.body.events.length).toBe(1);
+
+                const webhookEvent = req.body.events[0];
 
                 if (req.body.name === 'member_added') {
-                    expect(req.body.channel).toBe(channelName);
-                    expect([1, 2].includes(req.body.user_id)).toBe(true);
-                    expect(req.body.time_ms).toBeDefined();
+                    expect(webhookEvent.channel).toBe(channelName);
+                    expect(webhookEvent.user_id).toBe(2);
+                    expect([1, 2].includes(webhookEvent.user_id)).toBe(true);
                 }
 
                 res.json({ ok: true });
 
-                if (req.body.name === 'member_removed') {
-                    expect(req.body.channel).toBe(channelName);
-                    expect(req.body.time_ms).toBeDefined();
-                    expect(req.body.user_id).toBe(2);
+                if (webhookEvent.name === 'member_removed') {
+                    expect(webhookEvent.channel).toBe(channelName);
+                    expect(webhookEvent.user_id).toBe(2);
                     done();
                 }
             }, (activeHttpServer) => {


### PR DESCRIPTION
Fixes #137.

---

I've also added a little refactor to defer doing any real work for the webhook sending to the queue handler which is probably better for the socket server because a webhook is now a simple queue action instead of doing hmac calculation even when no webhooks are even defined. But feel free to revert / remove that commit if that is incorrect or unwanted.