### PR TITLE
[FIX] Changing cache channel implementaion to match the pusher protocol.

### DIFF
--- a/src/http-handler.ts
+++ b/src/http-handler.ts
@@ -386,7 +386,7 @@ export class HttpHandler {
 
             if (Utils.isCachingChannel(channel)) {
                 this.server.cacheManager.set(
-                    `app:${appId}:channel:${channel}:cache_miss`,
+                    `app:${appId}:channel:${channel}:cache`,
                     JSON.stringify({ event: msg.event, data: msg.data }),
                     this.server.options.channelLimits.cacheTtl,
                 );

--- a/src/http-handler.ts
+++ b/src/http-handler.ts
@@ -386,7 +386,7 @@ export class HttpHandler {
 
             if (Utils.isCachingChannel(channel)) {
                 this.server.cacheManager.set(
-                    `app:${appId}:channel:${channel}:cache`,
+                    `app:${appId}:channel:${channel}:cache_miss`,
                     JSON.stringify({ event: msg.event, data: msg.data }),
                     this.server.options.channelLimits.cacheTtl,
                 );

--- a/src/ws-handler.ts
+++ b/src/ws-handler.ts
@@ -698,10 +698,10 @@ export class WsHandler {
     sendMissedCacheIfExists(ws: WebSocket, channel: string) {
         this.server.cacheManager.get(`app:${ws.app.id}:channel:${channel}:cache_miss`).then(cachedEvent => {
             if (cachedEvent) {
-                let {event, data} = JSON.parse(cachedEvent)
-                ws.sendJson({ event: event, channel, data: data});
+                let { event, data } = JSON.parse(cachedEvent);
+                ws.sendJson({ event: event, channel, data: data });
             } else {
-                ws.sendJson({ event: 'pusher:cache_miss', channel});
+                ws.sendJson({ event: 'pusher:cache_miss', channel });
                 this.server.webhookSender.sendCacheMissed(ws.app, channel);
             }
         });

--- a/src/ws-handler.ts
+++ b/src/ws-handler.ts
@@ -696,7 +696,7 @@ export class WsHandler {
      * Send the first event as cache_missed, if it exists, to catch up.
      */
     sendMissedCacheIfExists(ws: WebSocket, channel: string) {
-        this.server.cacheManager.get(`app:${ws.app.id}:channel:${channel}:cache`).then(cachedEvent => {
+        this.server.cacheManager.get(`app:${ws.app.id}:channel:${channel}:cache_miss`).then(cachedEvent => {
             if (cachedEvent) {
                 let {event, data} = JSON.parse(cachedEvent)
                 ws.sendJson({ event: event, channel, data: data});

--- a/src/ws-handler.ts
+++ b/src/ws-handler.ts
@@ -696,10 +696,12 @@ export class WsHandler {
      * Send the first event as cache_missed, if it exists, to catch up.
      */
     sendMissedCacheIfExists(ws: WebSocket, channel: string) {
-        this.server.cacheManager.get(`app:${ws.app.id}:channel:${channel}:cache_miss`).then(cachedEvent => {
+        this.server.cacheManager.get(`app:${ws.app.id}:channel:${channel}:cache`).then(cachedEvent => {
             if (cachedEvent) {
-                ws.sendJson({ event: 'pusher:cache_miss', channel, data: cachedEvent });
+                let {event, data} = JSON.parse(cachedEvent)
+                ws.sendJson({ event: event, channel, data: data});
             } else {
+                ws.sendJson({ event: 'pusher:cache_miss', channel});
                 this.server.webhookSender.sendCacheMissed(ws.app, channel);
             }
         });

--- a/tests/presence.test.ts
+++ b/tests/presence.test.ts
@@ -334,21 +334,24 @@ describe('presence channel test', () => {
                 let channel = client1.subscribe(channelName);
 
                 channel.bind('pusher:subscription_succeeded', () => {
-                    channel.bind('greeting', e => {
-                        expect(e.message).toBe('hello');
+                    channel.bind('pusher:cache_miss', (data) => {
+                        expect(data).toBe(undefined);
 
-                        let client2 = Utils.newClientForPresenceUser(alice);
-
-                        client2.connection.bind('connected', () => {
-                            let channel = client2.subscribe(channelName);
-
-                            channel.bind('pusher:cache_miss', ({ event, data }) => {
-                                expect(event).toBe('greeting');
-                                expect(data).toBe(JSON.stringify({ message: 'hello'}));
-
-                                client1.disconnect();
-                                client2.disconnect();
-                                done();
+                        channel.bind('greeting', e => {
+                            expect(e.message).toBe('hello');
+    
+                            let client2 = Utils.newClientForPresenceUser(alice);
+    
+                            client2.connection.bind('connected', () => {
+                                let channel = client2.subscribe(channelName);
+    
+                                channel.bind('greeting', e => {
+                                    expect(e.message).toBe('hello');
+                                    done()
+                                })
+                                channel.bind('pusher:cache_miss', () => {
+                                    throw new Error('Did not expect cache_miss to be invoked.');
+                                });
                             });
                         });
                     });

--- a/tests/private.test.ts
+++ b/tests/private.test.ts
@@ -154,21 +154,25 @@ describe('private channel test', () => {
                 let channel = client1.subscribe(channelName);
 
                 channel.bind('pusher:subscription_succeeded', () => {
-                    channel.bind('greeting', e => {
-                        expect(e.message).toBe('hello');
+                    channel.bind('pusher:cache_miss', (data) => {
+                        expect(data).toBe(undefined);
 
-                        let client2 = Utils.newClientForPrivateChannel();
+                        channel.bind('greeting', e => {
+                            expect(e.message).toBe('hello');
+    
+                            let client2 = Utils.newClientForPrivateChannel();
+    
+                            client2.connection.bind('connected', () => {
+                                let channel = client2.subscribe(channelName);
 
-                        client2.connection.bind('connected', () => {
-                            let channel = client2.subscribe(channelName);
+                                channel.bind('pusher:cache_miss', () => {
+                                    throw new Error('Did not expect cache_miss to be invoked.');
+                                });
 
-                            channel.bind('pusher:cache_miss', ({ event, data }) => {
-                                expect(event).toBe('greeting');
-                                expect(data).toBe(JSON.stringify({ message: 'hello'}));
-
-                                client1.disconnect();
-                                client2.disconnect();
-                                done();
+                                channel.bind('greeting', e => {
+                                    expect(e.message).toBe('hello');
+                                    done()
+                                })
                             });
                         });
                     });

--- a/tests/public.test.ts
+++ b/tests/public.test.ts
@@ -123,21 +123,25 @@ describe('public channel test', () => {
                 let channel = client1.subscribe(channelName);
 
                 channel.bind('pusher:subscription_succeeded', () => {
-                    channel.bind('greeting', e => {
-                        expect(e.message).toBe('hello');
+                    channel.bind('pusher:cache_miss', (data) => {
+                        expect(data).toBe(undefined);
 
-                        let client2 = Utils.newClient();
+                        channel.bind('greeting', e => {
+                            expect(e.message).toBe('hello');
+    
+                            let client2 = Utils.newClient();
+    
+                            client2.connection.bind('connected', () => {
+                                let channel = client2.subscribe(channelName);
 
-                        client2.connection.bind('connected', () => {
-                            let channel = client2.subscribe(channelName);
+                                channel.bind('pusher:cache_miss', () => {
+                                    throw new Error('Did not expect cache_miss to be invoked.');
+                                });
 
-                            channel.bind('pusher:cache_miss', ({ event, data }) => {
-                                expect(event).toBe('greeting');
-                                expect(data).toBe(JSON.stringify({ message: 'hello'}));
-
-                                client1.disconnect();
-                                client2.disconnect();
-                                done();
+                                channel.bind('greeting', e => {
+                                    expect(e.message).toBe('hello');
+                                    done()
+                                })
                             });
                         });
                     });


### PR DESCRIPTION
Fixes #710
Fixes #935

- Changed the cache key to "app:${app_id}:channel:${channel_id}:cache"
- Send pusher:cache_miss event without any data to the client when the cache is empty
- Send the cached event when the cache is not empty
- Not sending the pusher:cache_miss event when the cache is not empty
- Added Tests