### PR TITLE
[1.x] Bypass call of `getSocketsCount` on new connections if `maxConnections` is set to unlimited

### DIFF
--- a/src/ws-handler.ts
+++ b/src/ws-handler.ts
@@ -740,13 +740,13 @@ export class WsHandler {
      * Return a boolean wether the user can connect or not.
      */
     protected checkAppConnectionLimit(ws: WebSocket): Promise<boolean> {
+        let maxConnections = parseInt(ws.app.maxConnections as string) || -1;
+
+        if (maxConnections < 0) {
+            return Promise.resolve(true);
+        }
+
         return this.server.adapter.getSocketsCount(ws.app.id).then(wsCount => {
-            let maxConnections = parseInt(ws.app.maxConnections as string) || -1;
-
-            if (maxConnections < 0) {
-                return true;
-            }
-
             return wsCount + 1 <= maxConnections;
         }).catch(err => {
             Log.error(err);


### PR DESCRIPTION
Closes https://github.com/soketi/soketi/issues/846