### PR TITLE
Feature: (experimental) Track connections numbers with a Redis key

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -168,6 +168,7 @@ jobs:
           AWS_SECRET_ACCESS_KEY: fake-secret
           SOKETI_DB_MYSQL_USERNAME: root
           SOKETI_DB_MYSQL_PASSWORD: root
+          SOKETI_ADAPTER_REDIS_USE_INCREMENTING_KEYS: true
 
       - name: Run Soketi (port 6002)
         if: "matrix.adapter == 'redis' || matrix.adapter == 'cluster' || matrix.adapter == 'nats'"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,22 +40,32 @@ jobs:
             rate_limiter: local
             queue_driver: sync
             cache_driver: memory
+            incrementing_keys: false
           - adapter: local
             rate_limiter: local
             queue_driver: sqs
             cache_driver: memory
+            incrementing_keys: false
           - adapter: cluster
             rate_limiter: cluster
             queue_driver: sync
             cache_driver: redis
+            incrementing_keys: false
           - adapter: redis
             rate_limiter: redis
             queue_driver: redis
             cache_driver: redis
+            incrementing_keys: true
+          - adapter: redis
+            rate_limiter: redis
+            queue_driver: redis
+            cache_driver: redis
+            incrementing_keys: false
           - adapter: nats
             rate_limiter: redis
             queue_driver: sync
             cache_driver: redis
+            incrementing_keys: false
 
     name: Node.js ${{ matrix.node }} (adapter:${{ matrix.adapter }} manager:${{ matrix.app_manager }} ratelimiter:${{ matrix.rate_limiter }} queue:${{ matrix.queue_driver }})
 
@@ -135,6 +145,7 @@ jobs:
           TEST_MYSQL_USER: root
           TEST_MYSQL_PASSWORD: root
           TEST_SQS_URL: http://localhost:4566/000000000000/test.fifo
+          TEST_ADAPTER_REDIS_USE_INCREMENTING_KEYS: ${{ matrix.incrementing_keys }}
           AWS_ACCESS_KEY_ID: fake-id
           AWS_SECRET_ACCESS_KEY: fake-secret
 

--- a/src/adapters/adapter-interface.ts
+++ b/src/adapters/adapter-interface.ts
@@ -36,6 +36,11 @@ export interface AdapterInterface {
     addSocket(appId: string, ws: WebSocket): Promise<boolean>;
 
     /**
+     * Update a socket in the namespace.
+     */
+    updateSocket(appId: string, ws: WebSocket): Promise<boolean>;
+
+    /**
      * Remove a socket from the namespace.
      */
     removeSocket(appId: string, wsId: string): Promise<boolean>;

--- a/src/adapters/adapter.ts
+++ b/src/adapters/adapter.ts
@@ -61,6 +61,13 @@ export class Adapter implements AdapterInterface {
     }
 
     /**
+     * Update a socket in the namespace.
+     */
+    async updateSocket(appId: string, ws: WebSocket): Promise<boolean> {
+        return this.driver.updateSocket(appId, ws);
+    }
+
+    /**
      * Remove a socket from the namespace.
      */
     async removeSocket(appId: string, wsId: string): Promise<boolean> {

--- a/src/adapters/horizontal-adapter.ts
+++ b/src/adapters/horizontal-adapter.ts
@@ -525,34 +525,6 @@ export abstract class HorizontalAdapter extends LocalAdapter {
     }
 
     /**
-     * Check if a given connection ID exists in a channel.
-     */
-    async isInChannel(appId: string, channel: string, wsId: string, onlyLocal?: boolean): Promise<boolean> {
-        return new Promise((resolve, reject) => {
-            super.isInChannel(appId, channel, wsId).then(existsLocally => {
-                if (onlyLocal || existsLocally) {
-                    return resolve(existsLocally);
-                }
-
-                this.getNumSub().then(numSub => {
-                    if (numSub <= 1) {
-                        return resolve(existsLocally);
-                    }
-
-                    return this.sendRequest(
-                        appId,
-                        RequestType.SOCKET_EXISTS_IN_CHANNEL,
-                        resolve,
-                        reject,
-                        { numSub },
-                        { opts: { channel, wsId } },
-                    );
-                });
-            });
-        });
-    }
-
-    /**
      * Listen for requests coming from other nodes.
      */
     protected onRequest(channel: string, msg: string): void {
@@ -648,14 +620,6 @@ export abstract class HorizontalAdapter extends LocalAdapter {
                 this.processRequestFromAnotherInstance(request, () => {
                     return super.getChannelSocketsCount(appId, request.opts.channel).then(localCount => {
                         return { totalCount: localCount };
-                    });
-                });
-                break;
-
-            case RequestType.SOCKET_EXISTS_IN_CHANNEL:
-                this.processRequestFromAnotherInstance(request, () => {
-                    return super.isInChannel(appId, request.opts.channel, request.opts.wsId).then(existsLocally => {
-                        return { exists: existsLocally };
                     });
                 });
                 break;

--- a/src/adapters/local-adapter.ts
+++ b/src/adapters/local-adapter.ts
@@ -53,6 +53,13 @@ export class LocalAdapter implements AdapterInterface {
     }
 
     /**
+     * Update a socket in the namespace.
+     */
+    async updateSocket(appId: string, ws: WebSocket): Promise<boolean> {
+        return this.getNamespace(appId).addSocket(ws);
+    }
+
+    /**
      * Remove a socket from the namespace.
      */
     async removeSocket(appId: string, wsId: string): Promise<boolean> {

--- a/src/adapters/redis-adapter.ts
+++ b/src/adapters/redis-adapter.ts
@@ -137,7 +137,7 @@ export class RedisAdapter extends HorizontalAdapter {
             && !this.syncIntervals[appId]
         ) {
             this.syncIntervals[appId] = setInterval(() => {
-                this.getSocketsCount(appId).then((socketsCount) => {
+                super.getSocketsCount(appId).then((socketsCount) => {
                     this.pubClient.set(`app:${appId}:connections_count`, socketsCount);
                 });
             }, Math.floor(Math.random() * (60 - 10 + 1) + 10) * 1e3);

--- a/src/adapters/redis-adapter.ts
+++ b/src/adapters/redis-adapter.ts
@@ -23,7 +23,7 @@ export class RedisAdapter extends HorizontalAdapter {
 
     protected syncIntervals: {
         [appId: string]: NodeJS.Timeout;
-    };
+    } = {};
 
     /**
      * Initialize the adapter.
@@ -223,17 +223,36 @@ export class RedisAdapter extends HorizontalAdapter {
         // the list of all sockets and count them from each node.
         if (this.server.options.adapter.redis.useIncrementingKeys) {
             return new Promise((resolve, reject) => {
-                this.pubClient.get(`app:${appId}:connections_count`, (err, socketsCount) => {
-                    if (err) {
-                        return reject(err);
-                    }
-
+                this.pubClient.get(`app:${appId}:connections_count`).then((socketsCount) => {
                     return resolve(parseInt(socketsCount, 10) || 0);
                 });
             });
         }
 
         return super.getSocketsCount(appId, onlyLocal);
+    }
+
+    /**
+     * Get a given channel's total sockets count.
+     */
+    async getChannelSocketsCount(appId: string, channel: string, onlyLocal?: boolean): Promise<number> {
+        if (onlyLocal) {
+            return super.getChannelSocketsCount(appId, channel, onlyLocal);
+        }
+
+        // Experimental: this will take a value of an incremented field
+        // from Redis, whose increment/decrement values (or get) are all O(1)
+        // This will perform better than O(N+M) that would require to iterate over
+        // the list of all sockets and count them from each node.
+        if (this.server.options.adapter.redis.useIncrementingKeys) {
+            return new Promise((resolve, reject) => {
+                this.pubClient.get(`app:${appId}:channel:${channel}:subscriptions_count`).then(count => {
+                    return resolve(parseInt(count, 10) || 0);
+                });
+            });
+        }
+
+        return super.getChannelSocketsCount(appId, channel, onlyLocal);
     }
 
     /**
@@ -259,6 +278,32 @@ export class RedisAdapter extends HorizontalAdapter {
             }
 
             return removed;
+        });
+    }
+
+    /**
+     * Add a socket ID to the channel identifier.
+     * Return the total number of connections after the connection.
+     */
+    async addToChannel(appId: string, channel: string, ws: WebSocket): Promise<number> {
+        return super.addToChannel(appId, channel, ws).then((count) => {
+            if (this.server.options.adapter.redis.useIncrementingKeys) {
+                return this.pubClient.incr(`app:${appId}:channel:${channel}:subscriptions_count`);
+            }
+
+            return count;
+        });
+    }
+
+    /**
+     * Remove a socket ID from the channel identifier.
+     * Return the total number of connections remaining to the channel.
+     */
+    async removeFromChannel(appId: string, channel: string|string[], wsId: string): Promise<number|void> {
+        return super.removeFromChannel(appId, channel, wsId).then(() => {
+            if (this.server.options.adapter.redis.useIncrementingKeys) {
+                this.pubClient.decr(`app:${appId}:channel:${channel}:subscriptions_count`);
+            }
         });
     }
 }

--- a/src/adapters/redis-adapter.ts
+++ b/src/adapters/redis-adapter.ts
@@ -196,7 +196,7 @@ export class RedisAdapter extends HorizontalAdapter {
      * Clear the connections.
      */
     disconnect(): Promise<void> {
-        return Promise.all([
+        return Promise.allSettled([
             this.subClient.quit(),
             this.pubClient.quit(),
             ...(Object.keys(this.syncIntervals).map(key => new Promise<void>(resolve => {

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -21,6 +21,7 @@ export class Cli {
         ADAPTER_REDIS_REQUESTS_TIMEOUT: 'adapter.redis.requestsTimeout',
         ADAPTER_REDIS_SUB_OPTIONS: 'adapter.redis.redisSubOptions',
         ADAPTER_REDIS_PUB_OPTIONS: 'adapter.redis.redisPubOptions',
+        ADAPTER_REDIS_USE_INCREMENTING_KEYS: 'adapter.redis.useIncrementingKeys',
         ADAPTER_NATS_PREFIX: 'adapter.nats.prefix',
         ADAPTER_NATS_SERVERS: 'adapter.nats.servers',
         ADAPTER_NATS_USER: 'adapter.nats.user',

--- a/src/options.ts
+++ b/src/options.ts
@@ -43,6 +43,7 @@ export interface Options {
             redisPubOptions: any;
             redisSubOptions: any;
             clusterMode: boolean;
+            useIncrementingKeys: boolean;
         };
         cluster: {
             requestsTimeout: 5_000,

--- a/src/server.ts
+++ b/src/server.ts
@@ -40,6 +40,7 @@ export class Server {
                     //
                 },
                 clusterMode: false,
+                useIncrementingKeys: false,
             },
             cluster: {
                 requestsTimeout: 5_000,

--- a/src/ws-handler.ts
+++ b/src/ws-handler.ts
@@ -742,13 +742,13 @@ export class WsHandler {
      * Return a boolean wether the user can connect or not.
      */
     protected checkAppConnectionLimit(ws: WebSocket): Promise<boolean> {
+        let maxConnections = parseInt(ws.app.maxConnections as string) || -1;
+
+        if (maxConnections < 0) {
+            return Promise.resolve(true);
+        }
+
         return this.server.adapter.getSocketsCount(ws.app.id).then(wsCount => {
-            let maxConnections = parseInt(ws.app.maxConnections as string) || -1;
-
-            if (maxConnections < 0) {
-                return true;
-            }
-
             return wsCount + 1 <= maxConnections;
         }).catch(err => {
             Log.error(err);

--- a/src/ws-handler.ts
+++ b/src/ws-handler.ts
@@ -381,7 +381,7 @@ export class WsHandler {
             }
 
             // Make sure to update the socket after new data was pushed in.
-            this.server.adapter.addSocket(ws.app.id, ws);
+            this.server.adapter.updateSocket(ws.app.id, ws);
 
             // If the connection freshly joined, send the webhook:
             if (response.channelConnections === 1) {
@@ -411,7 +411,7 @@ export class WsHandler {
                 ws.presence.set(channel, response.member);
 
                 // Make sure to update the socket after new data was pushed in.
-                this.server.adapter.addSocket(ws.app.id, ws);
+                this.server.adapter.updateSocket(ws.app.id, ws);
 
                 // If the member already exists in the channel, don't resend the member_added event.
                 if (!members.has(user_id as string)) {
@@ -478,7 +478,7 @@ export class WsHandler {
                     ws.presence.delete(channel);
 
                     // Make sure to update the socket after new data was pushed in.
-                    this.server.adapter.addSocket(ws.app.id, ws);
+                    this.server.adapter.updateSocket(ws.app.id, ws);
 
                     this.server.adapter.getChannelMembers(ws.app.id, channel, false).then(members => {
                         if (!members.has(member.user_id as string)) {
@@ -500,7 +500,7 @@ export class WsHandler {
                 // Make sure to update the socket after new data was pushed in,
                 // but only if the user is not closing the connection.
                 if (!closing) {
-                    this.server.adapter.addSocket(ws.app.id, ws);
+                    this.server.adapter.updateSocket(ws.app.id, ws);
                 }
 
                 if (response.remainingConnections === 0) {
@@ -681,7 +681,7 @@ export class WsHandler {
                 clearTimeout(ws.userAuthenticationTimeout);
             }
 
-            this.server.adapter.addSocket(ws.app.id, ws);
+            this.server.adapter.updateSocket(ws.app.id, ws);
 
             this.server.adapter.addUser(ws).then(() => {
                 ws.sendJson({

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -67,6 +67,7 @@ export class Utils {
             'database.postgres.database': process.env.TEST_POSTGRES_DATABASE || 'testing',
             'queue.sqs.queueUrl': process.env.TEST_SQS_URL || 'http://localhost:4566/000000000000/test.fifo',
             'debug': process.env.TEST_DEBUG || false,
+            'adapter.redis.useIncrementingKeys': process.env.TEST_ADAPTER_REDIS_USE_INCREMENTING_KEYS || false,
             'shutdownGracePeriod': 1_000,
         };
 


### PR DESCRIPTION
I saw that when the maxConnections number is > 1, the more instances you have, the more traffic it will be generated across Redis and it will throttle more the final actions of connecting/disconnecting.

## Synopsis

Previously, it was used a `getSocketsCount` each time a new client joined. This caused an `O(N+M)` on the publish towards other nodes to actually signal them to send back the total amounts of connections, and the subsequent nodes would require a `O(N+M)` for the response. `N` is the number of clients subscribed to the receiving channel (the number of Soketi instances) and M is the total number of subscribed patterns (by any client; in this case, 0).

So it had a `O(2N)` compelxity for the publishes, in case we don't assume for the time taken to process the data before sending it back to the node that requested it.

## Solution

Now, there is a key in the database that increments/decrements whenever a new connection joins or leaves. `INCRBY` and `DECRBY` are `O(1)`, so there will be extra incrementing/decrementing operations, but they are all constant complexity. When the value of current connections is needed, the `get` operation is also a `O(1)` complexity.

So in the end, it will be:

- user connects
- user gets the current sockets number -> `O(1)`
- if the maxConnections is not reached, increment the value -> `O(1)`
- ... time passes
- the user leaves, decrement the value -> `O(1)`

Each connection will generate a `O(2)`, and an `O(1)` on leave. The previous approach caused an `O(2N)` on connection, and no big O complexity as it does not signal anything.

To prevent any flops caused by improper termination (SIGKILLS, etc.), there is an interval created within the Redis adapter that will sync the connections count in Redis, at an interval between 10 and 60 seconds, which is assigned on the first run.

The final plot looks like this. As you can see, the `getSocketsCount()` operation is no longer liniar with a factor of 2, but it is constant. Since the adapter is horizontal, having equal performance when Soketi instances = 2 is giving a clue that the more nodes you have, the worse the performance gets with the current implementation, and the new one will fix a ton of issues.

<img width="894" alt="image" src="https://github.com/soketi/soketi/assets/21983456/c7fdca1a-e4c4-4b0f-996b-d47145b918b8">


