### PR TITLE
Add custom idleTimeout env variable

### DIFF
--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -104,6 +104,7 @@ export class Cli {
         METRICS_SERVER_PORT: 'metrics.port',
         MODE: 'mode',
         PORT: 'port',
+        IDLE_TIMEOUT: 'idleTimeout',
         PATH_PREFIX: 'pathPrefix',
         PRESENCE_MAX_MEMBER_SIZE: 'presence.maxMemberSizeInKb',
         PRESENCE_MAX_MEMBERS: 'presence.maxMembersPerChannel',

--- a/src/options.ts
+++ b/src/options.ts
@@ -150,6 +150,7 @@ export interface Options {
     };
     mode: string;
     port: number;
+    idleTimeout: number;
     pathPrefix: string;
     presence: {
         maxMembersPerChannel: string|number;

--- a/src/server.ts
+++ b/src/server.ts
@@ -195,6 +195,7 @@ export class Server {
         },
         mode: 'full',
         port: 6001,
+        idleTimeout : 120,  // According to protocol
         pathPrefix: '',
         presence: {
             maxMembersPerChannel: 100,
@@ -632,7 +633,7 @@ export class Server {
         return new Promise(resolve => {
             if (this.canProcessRequests()) {
                 server = server.ws(this.url('/app/:id'), {
-                    idleTimeout: 120, // According to protocol
+                    idleTimeout: this.options.idleTimeout,
                     maxBackpressure: 1024 * 1024,
                     maxPayloadLength: 100 * 1024 * 1024, // 100 MB
                     message: (ws: WebSocket, message: uWebSocketMessage, isBinary: boolean) => this.wsHandler.onMessage(ws, message, isBinary),

--- a/src/ws-handler.ts
+++ b/src/ws-handler.ts
@@ -812,7 +812,7 @@ export class WsHandler {
             } catch (e) {
                 //
             }
-        }, 120_000);
+        }, this.server.options.idleTimeout * 1000);
     }
 
     /**


### PR DESCRIPTION
# Custom idleTimeout env variable

## Current state

timeout is hardcoded in the server and the handler to 120 according to the ws protocol

![image](https://github.com/soketi/soketi/assets/22668814/3a4bc640-cfdd-45b5-b4d1-5d612a513e57)

## Why this is important
A Custom idleTimeout is necessary specially in testing environment , some use cases are :
- app still in development 
- testing ws with postman
- internal or local production env

## Changes :
- added the SOKETI_IDLE_TIMEOUT env variable in `cli.ts`
- added the idleTimeout as a number in `options.ts`
- settled the variable as the option indicates with a default of 120, `server.ts` & `ws-handler.ts`

## Result 
`SOKETI_IDLE_TIMEOUT=180 node bin/server.js start`

![image](https://github.com/soketi/soketi/assets/22668814/b5964376-4cfe-450f-8757-c7f484a0912d)
