### PR TITLE
build: jump to node 18.

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -18,7 +18,7 @@ jobs:
 
       matrix:
         node:
-          - 16.x
+          - 18.x
         adapter:
           - local
           - redis

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
 
       matrix:
         node:
-          - 16.x
+          - 18.x
         adapter:
           - local
           - redis

--- a/.github/workflows/docker-commit.yml
+++ b/.github/workflows/docker-commit.yml
@@ -24,7 +24,7 @@ jobs:
 
       matrix:
         node:
-          - '16'
+          - '18'
 
     name: Tag Alpine Commit (node:${{ matrix.node }})
 
@@ -86,7 +86,7 @@ jobs:
 
       matrix:
         node:
-          - '16'
+          - '18'
 
     name: Tag Distroless Commit (node:${{ matrix.node }})
 
@@ -148,7 +148,7 @@ jobs:
 
       matrix:
         node:
-          - '16'
+          - '18'
 
     name: Tag Debian Commit (node:${{ matrix.node }})
 

--- a/.github/workflows/docker-latest-tag.yml
+++ b/.github/workflows/docker-latest-tag.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       matrix:
         node:
-          - '16'
+          - '18'
 
     name: Tag Latest Alpine (node:${{ matrix.node }})
 
@@ -81,7 +81,7 @@ jobs:
     strategy:
       matrix:
         node:
-          - '16'
+          - '18'
 
     name: Tag Latest Distroless (node:${{ matrix.node }})
 
@@ -138,7 +138,7 @@ jobs:
     strategy:
       matrix:
         node:
-          - '16'
+          - '18'
 
     name: Tag Latest Debian (node:${{ matrix.node }})
 

--- a/.github/workflows/docker-release-tag.yml
+++ b/.github/workflows/docker-release-tag.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         node:
-          - '16'
+          - '18'
 
     name: Tag Alpine Release (node:${{ matrix.node }})
 
@@ -77,7 +77,7 @@ jobs:
     strategy:
       matrix:
         node:
-          - '16'
+          - '18'
 
     name: Tag Distroless Release (node:${{ matrix.node }})
 
@@ -137,7 +137,7 @@ jobs:
     strategy:
       matrix:
         node:
-          - '16'
+          - '18'
 
     name: Tag Debian Release (node:${{ matrix.node }})
 

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -17,9 +17,9 @@ jobs:
       - uses: actions/checkout@v4.1.0
 
       - uses: actions/setup-node@v3.8.1
-        name: Installing Node.js v16.x
+        name: Installing Node.js v18.x
         with:
-          node-version: 16.x
+          node-version: 18.x
 
       - uses: actions/cache@v3.3.2
         name: Cache npm dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG VERSION=lts
+ARG VERSION=18
 
 FROM --platform=$BUILDPLATFORM node:$VERSION-alpine as build
 

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -1,4 +1,4 @@
-ARG VERSION=lts
+ARG VERSION=18
 
 FROM --platform=$BUILDPLATFORM node:$VERSION-bullseye as build
 

--- a/Dockerfile.distroless
+++ b/Dockerfile.distroless
@@ -1,4 +1,4 @@
-ARG VERSION=16
+ARG VERSION=18
 
 FROM --platform=$BUILDPLATFORM node:$VERSION-alpine as base
 


### PR DESCRIPTION
![Screenshot 2024-01-11 at 9 39 17 AM](https://github.com/soketi/soketi/assets/611784/a20e8ea9-7bbd-4697-919b-eaf0ec4e899a)

We see Node 16 is now past EOL, which means the stacking vulns on the docker images is increasing with no known way to resolve.

![image](https://github.com/soketi/soketi/assets/611784/c56956de-9749-4bd6-8e8d-f3349282b610)

I pulled this package down and ran the test suite against Node 18 and it passed. Ran it against Node 20 and it failed.

I imagine thats a bit more difficult to patch. So I thought I would go through the images and upgrade to 18. I debated keeping 16 in the matrix to do both, but since its EOL and no more patches - it seemed like a waste of space.

I'm sure this isn't the proper way to do this upgrade, especially since I changed `lts` to `18`, but since LTS is now 20. It seems safer to call out the specific node version in play.

Maybe this becomes a 2.0 branch?

fixes: https://github.com/soketi/soketi/issues/1028
