### PR TITLE
Fix Pusher client not receiving data in payload on subscription_succeeded event.

### DIFF
--- a/src/ws-handler.ts
+++ b/src/ws-handler.ts
@@ -393,6 +393,7 @@ export class WsHandler {
                 let broadcastMessage = {
                     event: 'pusher_internal:subscription_succeeded',
                     channel,
+                    data: JSON.stringify({}),
                 };
 
                 ws.sendJson(broadcastMessage);


### PR DESCRIPTION
Similar to https://github.com/laravel/reverb/issues/123

This PR fixes missing `data` in the payload for the `pusher_internal:subscription_succeeded` event.

JavaScript Pusher-compatible clients can gracefully handle the missing property. However, using mobile SDKs (e.g. Flutter and using forked official Pusher package - https://pub.dev/packages/pusher_channels_flutter) is broken as  the Pusher Swift implementation does not properly parse payload without `data`.