### PR TITLE
Fixed channel data signature

### DIFF
--- a/src/channels/private-channel-manager.ts
+++ b/src/channels/private-channel-manager.ts
@@ -62,6 +62,10 @@ export class PrivateChannelManager extends PublicChannelManager {
      * Get the data to sign for the token for specific channel.
      */
     protected getDataToSignForSignature(socketId: string, message: PusherMessage): string {
-        return `${socketId}:${message.data.channel}`;
+        let data =  `${socketId}:${message.data.channel}`
+        if (message.data.channel_data) {
+            data += `:${message.data.channel_data}`;
+        }
+        return data;
     }
 }

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -270,7 +270,7 @@ export class Utils {
     ): string {
         let token = new Pusher.Token(key, secret);
 
-        return key + ':' + token.sign(`${socketId}:${channel.name}`);
+        return key + ':' + token.sign(`${socketId}:${channel.name}${channel.channel_data ? ':' + channel.channel_data : ''}`);
     }
 
     static signTokenForPresenceChannel(


### PR DESCRIPTION
The [official PHP client](https://github.com/pusher/pusher-http-php) includes `channel_data`in [their signature](https://github.com/pusher/pusher-http-php/blob/de2f72296808f9cafa6a4462b15a768ff130cddb/src/Pusher.php#L901)

This leads to a subscription error on private channels.

This PR adds the `channel_data` in the signature if available.

